### PR TITLE
:sparkles: 게시글 제목 조회에 엘라스틱 서치 적용,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 
 ### properties ###
 application.properties
+application-main.properties
 
 ### env ###
 .env

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ dependencies {
     // AWS SQS
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
+
+    // elasticsearch
+
+    implementation 'co.elastic.clients:elasticsearch-java'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 // I AM PORT

--- a/src/main/java/com/sparta/wuzuzu/domain/community_posts/controller/CommunityPostsController.java
+++ b/src/main/java/com/sparta/wuzuzu/domain/community_posts/controller/CommunityPostsController.java
@@ -1,11 +1,13 @@
 package com.sparta.wuzuzu.domain.community_posts.controller;
 
 import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostDetailResponse;
+import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostElasticListResponse;
 import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostListRequest;
 import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostListResponse;
 import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostRequest;
 import com.sparta.wuzuzu.domain.community_posts.dto.CommunityPostResponse;
 import com.sparta.wuzuzu.domain.community_posts.service.CommunityPostsService;
+import com.sparta.wuzuzu.global.dto.request.ListRequest;
 import com.sparta.wuzuzu.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -81,6 +83,11 @@ public class CommunityPostsController {
     public ResponseEntity<CommunityPostListResponse> searchCommunityPosts(
         @ModelAttribute CommunityPostListRequest request) {
         return ResponseEntity.ok(communityPostsService.searchCommunityPosts(request));
+    }
+
+    @GetMapping("/search/keyword/{keyword}")
+    public ResponseEntity<CommunityPostElasticListResponse> searchCommunityPostsByTitle(@PathVariable String keyword, @ModelAttribute ListRequest request) {
+        return ResponseEntity.ok(communityPostsService.searchPostByKeyword(keyword, request));
     }
 
     @GetMapping("/{communityPostsId}")

--- a/src/main/java/com/sparta/wuzuzu/domain/community_posts/dto/CommunityElasticResponse.java
+++ b/src/main/java/com/sparta/wuzuzu/domain/community_posts/dto/CommunityElasticResponse.java
@@ -1,0 +1,29 @@
+package com.sparta.wuzuzu.domain.community_posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // 알려지지 않은 필드 무시
+public class CommunityElasticResponse {
+    private String title;
+    private String content;
+    private Long views;
+    private Long likeCount;
+    private Integer comments;
+    private Date timestamp;  // @timestamp 필드 추가
+
+    private User user;
+    private Long category;
+
+    @Data
+    public static class User {
+        private long userId;
+    }
+
+}

--- a/src/main/java/com/sparta/wuzuzu/domain/community_posts/dto/CommunityPostElasticListResponse.java
+++ b/src/main/java/com/sparta/wuzuzu/domain/community_posts/dto/CommunityPostElasticListResponse.java
@@ -1,0 +1,20 @@
+package com.sparta.wuzuzu.domain.community_posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.wuzuzu.global.dto.response.ListResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommunityPostElasticListResponse extends ListResponse {
+
+    private List<CommunityElasticResponse> postList;
+
+}

--- a/src/main/java/com/sparta/wuzuzu/domain/community_posts/repository/CustomCommunityPostElasticRepository.java
+++ b/src/main/java/com/sparta/wuzuzu/domain/community_posts/repository/CustomCommunityPostElasticRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.wuzuzu.domain.community_posts.repository;
+
+import com.sparta.wuzuzu.domain.community_posts.dto.CommunityElasticResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomCommunityPostElasticRepository {
+    Page<CommunityElasticResponse> findByTitleContaining(String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/sparta/wuzuzu/domain/community_posts/repository/CustomCommunityPostElasticRepositoryImpl.java
+++ b/src/main/java/com/sparta/wuzuzu/domain/community_posts/repository/CustomCommunityPostElasticRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.sparta.wuzuzu.domain.community_posts.repository;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.wuzuzu.domain.community_posts.dto.CommunityElasticResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class CustomCommunityPostElasticRepositoryImpl implements CustomCommunityPostElasticRepository {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    public CustomCommunityPostElasticRepositoryImpl(ElasticsearchClient elasticsearchClient) {
+        this.elasticsearchClient = elasticsearchClient;
+    }
+
+    @Override
+    public Page<CommunityElasticResponse> findByTitleContaining(String keyword, Pageable pageable) {
+        try {
+            SearchRequest request = new SearchRequest.Builder()
+                .index("community_posts")
+                .query(q -> q
+                    .match(m -> m
+                        .field("title")
+                        .query(keyword)
+                    )
+                )
+                .from((int) pageable.getOffset())
+                .size(pageable.getPageSize())
+                .build();
+
+            SearchResponse<Map> response = elasticsearchClient.search(request, Map.class);
+            List<CommunityElasticResponse> content = response.hits().hits().stream()
+                .map(hit -> {
+                    try {
+                        return mapToDto((Map<String, Object>) hit.source());
+                    } catch (Exception e) {
+                        log.error("Failed to convert map to DTO: {}", hit.source(), e);
+                        return null; // 또는 예외를 재발생시키지 않고 기본값을 반환
+                    }
+                })
+                .filter(Objects::nonNull) // null이 아닌 결과만 수집
+                .collect(Collectors.toList());
+
+            return new PageImpl<>(content, pageable, response.hits().total().value());
+        } catch (Exception e) {
+            log.error("Failed to search in Elasticsearch", e);
+            throw new RuntimeException("Failed to search in Elasticsearch", e);
+        }
+    }
+
+    private CommunityElasticResponse mapToDto(Map<String, Object> source) {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.convertValue(source, CommunityElasticResponse.class);
+    }
+}

--- a/src/main/java/com/sparta/wuzuzu/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/sparta/wuzuzu/global/config/ElasticsearchConfig.java
@@ -1,0 +1,48 @@
+package com.sparta.wuzuzu.global.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class ElasticsearchConfig {
+
+
+    @Value("${spring.elasticsearch.rest.uris}")
+    private String elasticsearchUrl;
+
+    @Value("${spring.elasticsearch.rest.apiKey}")
+    private String apiKey;
+
+    private final String authorization = "Authorization";
+    private final String key = "ApiKey ";
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder(HttpHost.create(elasticsearchUrl))
+            .setDefaultHeaders(new Header[]{new BasicHeader(authorization, key + apiKey)})
+            .build();
+    }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        RestClient restClient = restClient();
+        ElasticsearchTransport transport = new RestClientTransport(restClient,
+            new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+
+}
+
+
+
+


### PR DESCRIPTION
## 📝작업내용
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
1. application properties에서 
spring.elasticsearch.rest.uris=http://localhost:9200
spring.elasticsearch.rest.apiKey=자신이 kiabana에서 발급받은 api key로 변경해 주셔야 합니다
(키바나 로그인(localhost:5601) -> 좌측 상단 햄버거 -> 매니지먼트 -> 시큐리티 탭의 api key -> 가운데 옵션만 클릭 ->발급 -> 복사)

2. 기존에 다운 받았던 docker-elk  설정 파일에서 
elasticsearch.yml 파일에 xpack.security.authc.api_key.enabled: true 문장 추가.
.env 파일에서 
ELASTICSEARCH_HOST='localhost'
ELASTICSEARCH_PORT='9200'
ELASTICSEARCH_APIKEY='발급받은 api key'

스프링 부트에서 환경에서 돌려보시려면 반드시 개인적으로 api key 발급 받으셔야 합니다.
지금 입력되어 있는 키는 발급한 사람 로컬에서만 작동하는 키입니다.
<!---- Resolves: #(Issue Number) -->
## PR 유형
✨ 변경 사항
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] 의존성 추가 혹은 삭제
